### PR TITLE
feat: add exchange names to FAQ STEEM token description

### DIFF
--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -788,7 +788,9 @@ export default function FAQ() {
                       </p>
                       <div className="small-container">
                         <p>
-                          STEEM tokens can be traded on exchanges, converted to
+                          STEEM tokens can be traded on exchanges (such as
+                          Binance, Upbit, Gate, MEXC, HTX and Bithumb). Within
+                          the Steem ecosystem, they can also be converted to
                           Steem Power (SP) for increased voting power and
                           rewards, converted to SBD, or used for various
                           blockchain operations.


### PR DESCRIPTION
## Summary

- Add major exchanges (Binance, Upbit, Gate, MEXC, HTX, Bithumb) as examples in the FAQ section
- Help users identify trading channels for STEEM tokens
- Improve user awareness of available exchanges

## Changes

Updated the "What can I do with my STEEM tokens?" section in the FAQ page to include specific exchange names based on CoinMarketCap listing.

**Before:**
> STEEM tokens can be traded on exchanges, converted to Steem Power (SP)...

**After:**
> STEEM tokens can be traded on exchanges (such as Binance, Upbit, Gate, MEXC, HTX and Bithumb). Within the Steem ecosystem, they can also be converted to Steem Power (SP)...

## Test plan

- [x] Build passes locally (`pnpm run build`)
- [x] Verify FAQ page displays correctly at `/faq/#what-can-i-do-with-my-steem-tokens`
- [x] Confirm exchange names are displayed as expected